### PR TITLE
Warning fix

### DIFF
--- a/R/InternalFunctions.R
+++ b/R/InternalFunctions.R
@@ -17,11 +17,12 @@ geometric.mean <- function(Scores, L, N) {
     return(FinalScore)
 }
 
+col.means.helper <- function(value){
+    return( if (typeof(value) == 'character') NA else mean(value))
+}
 
 ## Functions to perform Random Walk with Restart on Multiplex Networks.
-
 simplify.layers <- function(Input_Layer){
-    
     ## Undirected Graphs
     Layer <- as.undirected(Input_Layer, mode = c("collapse"),
         edge.attr.comb = igraph_opt("edge.attr.comb"))
@@ -43,10 +44,9 @@ simplify.layers <- function(Input_Layer){
         E(Layer)$weight <- rep(1, ecount(Layer))
     }
     
-    ## Simple Graphs
     Layer <- 
         igraph::simplify(Layer,remove.multiple = TRUE,remove.loops = TRUE, 
-            edge.attr.comb=mean)
+            edge.attr.comb=col.means.helper)
     
     return(Layer)
 }

--- a/R/InternalFunctions.R
+++ b/R/InternalFunctions.R
@@ -43,7 +43,8 @@ simplify.layers <- function(Input_Layer){
     } else {
         E(Layer)$weight <- rep(1, ecount(Layer))
     }
-    
+
+    ## Simple Graphs
     Layer <- 
         igraph::simplify(Layer,remove.multiple = TRUE,remove.loops = TRUE, 
             edge.attr.comb=col.means.helper)


### PR DESCRIPTION
## Initial Issue

Without using a `suprressWarnings()` function call on `RandomWalkRestartMH::create.multiplex( LayersList=nwlist )`, the following warnings are displayed: 

```
Warning messages:
1: In mean.default("m1") :
  argument is not numeric or logical: returning NA
2: In mean.default("m1") :
  argument is not numeric or logical: returning NA
3: In mean.default("m1") :
  argument is not numeric or logical: returning NA
4: In mean.default("m2") :
  argument is not numeric or logical: returning NA
5: In mean.default("m2") :
  argument is not numeric or logical: returning NA
6: In mean.default("m2") :
  argument is not numeric or logical: returning NA
7: In mean.default("m2") :
  argument is not numeric or logical: returning NA
```



The warnings themselves come from the `simplify.layers` function within the `InternalFunctions.R` file.  The edges are simplified via the `graph::simplify` function, which uses the `mean` function for the `edge.attr.comb`. Not all edges are numeric with RandomWalkRestartMH's construction (e.g. `"m1"`, `"m2"`). 

```R
 Layer <- 
        igraph::simplify(Layer,remove.multiple = TRUE,remove.loops = TRUE, 
            edge.attr.comb=mean)    
```



Without a suppress warnings, upon testing within the RWRtools suite, our tests yield: 

```
══ Results ═══════════════════════════════════════
Duration: 1.4 s

[ FAIL 0 | WARN 77 | SKIP 0 | PASS 47 ]
```

The 77 Warnings are entirely `  argument is not numeric or logical: returning NA`. 





## Update

A helper function was created to stem these warnings: `col.means.helper`, which returns either desired means, or `NA`: 

```R
col.means.helper <- function(value){
    return( if (typeof(value) == 'character') NA else mean(value))
}
           
	...
		Layer <- 
			igraph::simplify(Layer,remove.multiple = TRUE,remove.loops = TRUE, 
			edge.attr.comb=col.means.helper)    
	...
```



With the new code, RWRtools tests return: 

```
══ Results ═══════════════════════════════════════
Duration: 0.8 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 47 ]
```

 